### PR TITLE
Bug fixes for removing port group and inspection port group hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/**
+**/.settings/**

--- a/src/main/java/org/osc/controller/nuage/api/NuageRestApi.java
+++ b/src/main/java/org/osc/controller/nuage/api/NuageRestApi.java
@@ -17,8 +17,7 @@ public class NuageRestApi implements AutoCloseable {
         ClassLoader oldCCL = Thread.currentThread().getContextClassLoader();
         try {
             Thread.currentThread().setContextClassLoader(this.getClass().getClassLoader());
-            // TODO sridhar: This should come from the VC.isControllerHttps() instead.
-            this.vsdSession = getNuageVSDSession(true);
+            this.vsdSession = getNuageVSDSession(this.vc.isControllerHttps());
         } finally {
             Thread.currentThread().setContextClassLoader(oldCCL);
         }

--- a/src/main/java/org/osc/controller/nuage/api/NuageSdnRedirectionApi.java
+++ b/src/main/java/org/osc/controller/nuage/api/NuageSdnRedirectionApi.java
@@ -14,6 +14,8 @@ import org.osc.sdk.controller.element.VirtualizationConnectorElement;
 import org.osc.sdk.controller.exception.NetworkPortNotFoundException;
 import org.springframework.util.CollectionUtils;
 
+import net.nuagenetworks.vspk.v4_0.IngressAdvFwdTemplate;
+
 public class NuageSdnRedirectionApi implements SdnRedirectionApi {
 
     private VirtualizationConnectorElement vc;
@@ -144,7 +146,8 @@ public class NuageSdnRedirectionApi implements SdnRedirectionApi {
         }
     }
 
-    public void removeInspectionPort( InspectionPortElement inspectionPort)
+    @Override
+    public void removeInspectionPort(InspectionPortElement inspectionPort)
             throws NetworkPortNotFoundException, Exception {
         String domainId = null;
         if (inspectionPort != null && inspectionPort.getIngressPort() != null) {
@@ -170,7 +173,13 @@ public class NuageSdnRedirectionApi implements SdnRedirectionApi {
 
     @Override
     public InspectionHookElement getInspectionHook(String inspectionHookId) throws Exception {
-        // TODO Auto-generated method stub
+        try (NuageSecurityControllerApi nuageSecApi = new NuageSecurityControllerApi(this.vc, this.config.port())){
+            IngressAdvFwdTemplate fwdPolicy = nuageSecApi.getFwdPolicy(inspectionHookId);
+            if (fwdPolicy != null) {
+                return new InpectionHookElementImpl(inspectionHookId);
+            }
+        }
+
         return null;
     }
 
@@ -178,5 +187,54 @@ public class NuageSdnRedirectionApi implements SdnRedirectionApi {
     public void updateInspectionHook(InspectionHookElement existingInspectionHook)
             throws NetworkPortNotFoundException, Exception {
         throw new NotImplementedException("Updating an inspeciton hook is currently not supported by this plugin");
+    }
+
+    private class InpectionHookElementImpl implements InspectionHookElement {
+        private String id;
+
+        InpectionHookElementImpl(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String getHookId() {
+            return this.id;
+        }
+
+        @Override
+        public Long getTag() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public Long getOrder() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public TagEncapsulationType getEncType() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public FailurePolicyType getFailurePolicyType() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public NetworkElement getInspectedPort() {
+            // TODO Auto-generated method stub
+            return null;
+        }
+
+        @Override
+        public InspectionPortElement getInspectionPort() {
+            // TODO Auto-generated method stub
+            return null;
+        }
     }
 }

--- a/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
@@ -2,10 +2,7 @@ package org.osc.controller.nuage;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.ops4j.pax.exam.CoreOptions.bundle;
-import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
-import static org.ops4j.pax.exam.CoreOptions.options;
+import static org.ops4j.pax.exam.CoreOptions.*;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
@@ -19,7 +16,12 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 
 import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
 import org.ops4j.pax.exam.util.PathUtils;
 import org.osc.sdk.controller.api.SdnControllerApi;
 import org.osc.sdk.controller.element.VirtualizationConnectorElement;
@@ -30,8 +32,8 @@ import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.util.tracker.ServiceTracker;
 
-//@RunWith(PaxExam.class)
-//@ExamReactorStrategy(PerMethod.class)
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
 public class OSGiIntegrationTest extends AbstractNuageTest {
     @Inject
     ConfigurationAdmin configAdmin;
@@ -133,7 +135,7 @@ public class OSGiIntegrationTest extends AbstractNuageTest {
         this.tracker.open();
     }
 
-    //@Test
+    @Test
     public void testRegistered() throws InterruptedException {
         SdnControllerApi service = this.tracker.waitForService(5000);
         assertNotNull(service);
@@ -151,7 +153,7 @@ public class OSGiIntegrationTest extends AbstractNuageTest {
      * we could start a simple local server to connect to...
      * @throws Exception
      */
-    //@Test
+    @Test
     public void testConnect() throws Exception {
         SdnControllerApi service = this.tracker.waitForService(5000);
         assertNotNull(service);


### PR DESCRIPTION
This PR contains the code for retrieving and deleting an inspection hook. It also calculates an available priority as it creates new inspection hooks. This is needed because Nuage does not support multiple active fwrd policies with the same priority. 
Additionally this PR re-enables the PAX tests now that the plugin can take the property isHttps from the provided virtualization connector (OSC previously was passing `false` but it has recently been fixed).