### PR TITLE
Fixing creation of repeated fwrd policies issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+             <version>2.8.5</version>
+             <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.cm</artifactId>
             <version>1.5.0</version>


### PR DESCRIPTION
This PR fixes the issue #20 by leveraging the field `externalId` instead of the mutable `id`.   
This PR also adds a test dependency that was missing, it seems that when this dependency was not found on the local mvn repository the tests were failing. 