### PR TITLE
Replace logging with slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.aopalliance</artifactId>
             <version>1.0_6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,12 +85,6 @@
             <version>1.7.25</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>
             <artifactId>org.apache.servicemix.bundles.aopalliance</artifactId>
             <version>1.0_6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
             <version>2.6</version>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-        </dependency>
-        <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.service.component.annotations</artifactId>
             <version>1.3.0</version>
@@ -87,7 +82,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.18</version>
+            <version>1.7.25</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.servicemix.bundles</groupId>

--- a/src/main/java/org/osc/controller/nuage/api/LogProvider.java
+++ b/src/main/java/org/osc/controller/nuage/api/LogProvider.java
@@ -16,19 +16,25 @@
  *******************************************************************************/
 package org.osc.controller.nuage.api;
 
+import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
+
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
 @Component
 public class LogProvider {
+    private static ConcurrentHashMap<String, Logger> loggerCache = new ConcurrentHashMap<>();
 
     private static ILoggerFactory loggerFactory;
 
-    @Reference
+    @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=GREEDY)
     public void setLoggerFactoryInst(ILoggerFactory instance) {
-        loggerFactory = instance;
+        setLoggerFactory(instance);
     }
 
     public static Logger getLogger(Object object) {
@@ -45,6 +51,15 @@ public class LogProvider {
             className = object.getClass().getName();
         }
 
-        return loggerFactory.getLogger(className);
+        if (!loggerCache.containsKey(className)) {
+            loggerCache.put(className, new LoggerProxy(className, loggerFactory));
+        }
+
+        return loggerCache.get(className);
     }
+
+    public static void setLoggerFactory(ILoggerFactory instance) {
+        loggerFactory = instance;
+    }
+
 }

--- a/src/main/java/org/osc/controller/nuage/api/LogProvider.java
+++ b/src/main/java/org/osc/controller/nuage/api/LogProvider.java
@@ -16,8 +16,6 @@
  *******************************************************************************/
 package org.osc.controller.nuage.api;
 
-import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.ILoggerFactory;
@@ -35,7 +33,7 @@ import org.slf4j.Logger;
 public class LogProvider {
     private static ILoggerFactory loggerFactory;
 
-    @Reference(policyOption=GREEDY)
+    @Reference
     public void setLoggerFactoryInst(ILoggerFactory instance) {
         setLoggerFactory(instance);
     }

--- a/src/main/java/org/osc/controller/nuage/api/LogProvider.java
+++ b/src/main/java/org/osc/controller/nuage/api/LogProvider.java
@@ -18,8 +18,6 @@ package org.osc.controller.nuage.api;
 
 import static org.osgi.service.component.annotations.ReferencePolicyOption.GREEDY;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -28,38 +26,22 @@ import org.slf4j.Logger;
 
 @Component
 public class LogProvider {
-    private static ConcurrentHashMap<String, Logger> loggerCache = new ConcurrentHashMap<>();
-
-    private static ILoggerFactory loggerFactory;
+    static ILoggerFactory loggerFactory;
 
     @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=GREEDY)
     public void setLoggerFactoryInst(ILoggerFactory instance) {
         setLoggerFactory(instance);
     }
 
-    public static Logger getLogger(Object object) {
-        if (object == null) {
+    public static Logger getLogger(Class<?> clazz) {
+        if (clazz == null) {
             throw new IllegalArgumentException("Attempt to get logger for null class!!");
         }
 
-        String className;
-        if (object instanceof Class) {
-            className = ((Class<?>) object).getName();
-        } else if (object instanceof String) {
-            className = (String) object;
-        } else {
-            className = object.getClass().getName();
-        }
-
-        if (!loggerCache.containsKey(className)) {
-            loggerCache.put(className, new LoggerProxy(className, loggerFactory));
-        }
-
-        return loggerCache.get(className);
+        return new LoggerProxy(clazz.getName());
     }
 
     public static void setLoggerFactory(ILoggerFactory instance) {
         loggerFactory = instance;
     }
-
 }

--- a/src/main/java/org/osc/controller/nuage/api/LogProvider.java
+++ b/src/main/java/org/osc/controller/nuage/api/LogProvider.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.controller.nuage.api;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+
+@Component
+public class LogProvider {
+
+    private static ILoggerFactory loggerFactory;
+
+    @Reference
+    public void setLoggerFactoryInst(ILoggerFactory instance) {
+        loggerFactory = instance;
+    }
+
+    public static Logger getLogger(Object object) {
+        if (object == null) {
+            throw new IllegalArgumentException("Attempt to get logger for null class!!");
+        }
+
+        String className;
+        if (object instanceof Class) {
+            className = ((Class<?>) object).getName();
+        } else if (object instanceof String) {
+            className = (String) object;
+        } else {
+            className = object.getClass().getName();
+        }
+
+        return loggerFactory.getLogger(className);
+    }
+}

--- a/src/main/java/org/osc/controller/nuage/api/LogProvider.java
+++ b/src/main/java/org/osc/controller/nuage/api/LogProvider.java
@@ -20,15 +20,22 @@ import static org.osgi.service.component.annotations.ReferencePolicyOption.GREED
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 
+/**
+ * This component Takes the properly initialized {@link ILoggerFactory}
+ * service from OSGi uses it to create {@link Logger} objects for other
+ * classes via a static {@code getLogger} method.
+ *
+ * @see org.osc.core.broker.util.log
+ * @see org.osc.core.server.Server
+ */
 @Component
 public class LogProvider {
-    static ILoggerFactory loggerFactory;
+    private static ILoggerFactory loggerFactory;
 
-    @Reference(cardinality=ReferenceCardinality.OPTIONAL, policyOption=GREEDY)
+    @Reference(policyOption=GREEDY)
     public void setLoggerFactoryInst(ILoggerFactory instance) {
         setLoggerFactory(instance);
     }
@@ -41,7 +48,11 @@ public class LogProvider {
         return new LoggerProxy(clazz.getName());
     }
 
-    public static void setLoggerFactory(ILoggerFactory instance) {
+    public static ILoggerFactory getLoggerFactory() {
+        return loggerFactory;
+    }
+
+    private static void setLoggerFactory(ILoggerFactory instance) {
         loggerFactory = instance;
     }
 }

--- a/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
+++ b/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
@@ -19,8 +19,8 @@ package org.osc.controller.nuage.api;
 import static org.osc.controller.nuage.api.LogProvider.getLoggerFactory;
 
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
+import org.slf4j.impl.SimpleLoggerFactory;
 
 /**
  * Wrapper around the properly initialized {@link Logger}, once available from {@link LogProvider}.
@@ -35,7 +35,7 @@ class LoggerProxy implements Logger {
 
     public LoggerProxy(String className) {
         this.className = className;
-        this.FALLBACK_IMPL = LoggerFactory.getLogger(className);
+        this.FALLBACK_IMPL = new SimpleLoggerFactory().getLogger(className);
     }
 
     @Override

--- a/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
+++ b/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
@@ -16,12 +16,17 @@
  *******************************************************************************/
 package org.osc.controller.nuage.api;
 
-import static org.osc.controller.nuage.api.LogProvider.loggerFactory;
+import static org.osc.controller.nuage.api.LogProvider.getLoggerFactory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
+/**
+ * Wrapper around the properly initialized {@link Logger}, once available from {@link LogProvider}.
+ * Delegates all the calls to that logger or to a standin logger in the meanwhile.
+ *
+ */
 class LoggerProxy implements Logger {
 
     private Logger properLogger;
@@ -343,8 +348,8 @@ class LoggerProxy implements Logger {
             return this.properLogger;
         }
 
-        if (loggerFactory != null) {
-            Logger implToUse = loggerFactory.getLogger(this.className);
+        if (getLoggerFactory() != null) {
+            Logger implToUse = getLoggerFactory().getLogger(this.className);
             synchronized (this) {
                 if (this.properLogger == null) {
                     this.properLogger = implToUse;

--- a/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
+++ b/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
@@ -1,0 +1,594 @@
+/*******************************************************************************
+ * Copyright (c) Intel Corporation
+ * Copyright (c) 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.osc.controller.nuage.api;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+
+public class LoggerProxy implements Logger {
+    private Logger properLogger;
+    private final Logger FALLBACK_IMPL;
+    private final String className;
+    private final ILoggerFactory loggerFactory;
+
+    public LoggerProxy(String className, ILoggerFactory atomicFactoryRef) {
+        this.className = className;
+        this.FALLBACK_IMPL = LoggerFactory.getLogger(className);
+        this.loggerFactory = atomicFactoryRef;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isTraceEnabled();
+        } else {
+            return findImplToUse().isTraceEnabled();
+        }
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isTraceEnabled(marker);
+        } else {
+            return findImplToUse().isTraceEnabled(marker);
+        }
+    }
+
+    @Override
+    public void trace(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(msg);
+        } else {
+            findImplToUse().trace(msg);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(format, arg);
+        } else {
+            findImplToUse().trace(format, arg);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(format, arg1, arg2);
+        } else {
+            findImplToUse().trace(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void trace(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(format, arguments);
+        } else {
+            findImplToUse().trace(format, arguments);
+        }
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(msg, t);
+        } else {
+            findImplToUse().trace(msg, t);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, msg);
+        } else {
+            findImplToUse().trace(marker, msg);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, format, arg);
+        } else {
+            findImplToUse().trace(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().trace(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, format, argArray);
+        } else {
+            findImplToUse().trace(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void trace(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.trace(marker, msg, t);
+        } else {
+            findImplToUse().trace(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isDebugEnabled();
+        } else {
+            return findImplToUse().isDebugEnabled();
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isDebugEnabled(marker);
+        } else {
+            return findImplToUse().isDebugEnabled(marker);
+        }
+    }
+
+    @Override
+    public void debug(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(msg);
+        } else {
+            findImplToUse().debug(msg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(format, arg);
+        } else {
+            findImplToUse().debug(format, arg);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(format, arg1, arg2);
+        } else {
+            findImplToUse().debug(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void debug(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(format, arguments);
+        } else {
+            findImplToUse().debug(format, arguments);
+        }
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(msg, t);
+        } else {
+            findImplToUse().debug(msg, t);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, msg);
+        } else {
+            findImplToUse().debug(marker, msg);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, format, arg);
+        } else {
+            findImplToUse().debug(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().debug(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, format, argArray);
+        } else {
+            findImplToUse().debug(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void debug(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.debug(marker, msg, t);
+        } else {
+            findImplToUse().debug(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isInfoEnabled();
+        } else {
+            return findImplToUse().isInfoEnabled();
+        }
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isInfoEnabled(marker);
+        } else {
+            return findImplToUse().isInfoEnabled(marker);
+        }
+    }
+
+    @Override
+    public void info(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(msg);
+        } else {
+            findImplToUse().info(msg);
+        }
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(format, arg);
+        } else {
+            findImplToUse().info(format, arg);
+        }
+    }
+
+    @Override
+    public void info(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.info(format, arg1, arg2);
+        } else {
+            findImplToUse().info(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void info(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.info(format, arguments);
+        } else {
+            findImplToUse().info(format, arguments);
+        }
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.info(msg, t);
+        } else {
+            findImplToUse().info(msg, t);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, msg);
+        } else {
+            findImplToUse().info(marker, msg);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, format, arg);
+        } else {
+            findImplToUse().info(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().info(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, format, argArray);
+        } else {
+            findImplToUse().info(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.info(marker, msg, t);
+        } else {
+            findImplToUse().info(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isWarnEnabled();
+        } else {
+            return findImplToUse().isWarnEnabled();
+        }
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isWarnEnabled(marker);
+        } else {
+            return findImplToUse().isWarnEnabled(marker);
+        }
+    }
+
+    @Override
+    public void warn(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(msg);
+        } else {
+            findImplToUse().warn(msg);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(format, arg);
+        } else {
+            findImplToUse().warn(format, arg);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(format, arg1, arg2);
+        } else {
+            findImplToUse().warn(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void warn(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(format, arguments);
+        } else {
+            findImplToUse().warn(format, arguments);
+        }
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(msg, t);
+        } else {
+            findImplToUse().warn(msg, t);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, msg);
+        } else {
+            findImplToUse().warn(marker, msg);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, format, arg);
+        } else {
+            findImplToUse().warn(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().warn(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, format, argArray);
+        } else {
+            findImplToUse().warn(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.warn(marker, msg, t);
+        } else {
+            findImplToUse().warn(marker, msg, t);
+        }
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        if (this.properLogger != null) {
+            return this.properLogger.isErrorEnabled();
+        } else {
+            return findImplToUse().isErrorEnabled();
+        }
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+        if (this.properLogger != null) {
+            return this.properLogger.isErrorEnabled(marker);
+        } else {
+            return findImplToUse().isErrorEnabled(marker);
+        }
+    }
+
+    @Override
+    public void error(String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(msg);
+        } else {
+            findImplToUse().error(msg);
+        }
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(format, arg);
+        } else {
+            findImplToUse().error(format, arg);
+        }
+    }
+
+    @Override
+    public void error(String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.error(format, arg1, arg2);
+        } else {
+            findImplToUse().error(format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void error(String format, Object... arguments) {
+        if (this.properLogger != null) {
+            this.properLogger.error(format, arguments);
+        } else {
+            findImplToUse().error(format, arguments);
+        }
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.error(msg, t);
+        } else {
+            findImplToUse().error(msg, t);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String msg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, msg);
+        } else {
+            findImplToUse().error(marker, msg);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, format, arg);
+        } else {
+            findImplToUse().error(marker, format, arg);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg1, Object arg2) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, format, arg1, arg2);
+        } else {
+            findImplToUse().error(marker, format, arg1, arg2);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object... argArray) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, format, argArray);
+        } else {
+            findImplToUse().error(marker, format, argArray);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String msg, Throwable t) {
+        if (this.properLogger != null) {
+            this.properLogger.error(marker, msg, t);
+        } else {
+            findImplToUse().error(marker, msg, t);
+        }
+    }
+
+    private Logger findImplToUse() {
+        if (this.loggerFactory != null) {
+            Logger implToUse = this.loggerFactory.getLogger(this.className);
+            synchronized (this) {
+                if (this.properLogger == null) {
+                    this.properLogger = implToUse;
+                }
+            }
+            return this.properLogger;
+        } else {
+            return this.FALLBACK_IMPL;
+        }
+    }
+}

--- a/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
+++ b/src/main/java/org/osc/controller/nuage/api/LoggerProxy.java
@@ -16,571 +16,335 @@
  *******************************************************************************/
 package org.osc.controller.nuage.api;
 
-import org.slf4j.ILoggerFactory;
+import static org.osc.controller.nuage.api.LogProvider.loggerFactory;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 
-public class LoggerProxy implements Logger {
+class LoggerProxy implements Logger {
+
     private Logger properLogger;
     private final Logger FALLBACK_IMPL;
     private final String className;
-    private final ILoggerFactory loggerFactory;
 
-    public LoggerProxy(String className, ILoggerFactory atomicFactoryRef) {
+    public LoggerProxy(String className) {
         this.className = className;
         this.FALLBACK_IMPL = LoggerFactory.getLogger(className);
-        this.loggerFactory = atomicFactoryRef;
     }
 
     @Override
     public String getName() {
-        return null;
+        return this.className;
     }
 
     @Override
     public boolean isTraceEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isTraceEnabled();
-        } else {
-            return findImplToUse().isTraceEnabled();
-        }
+        return findImplToUse().isTraceEnabled();
     }
 
     @Override
     public boolean isTraceEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isTraceEnabled(marker);
-        } else {
-            return findImplToUse().isTraceEnabled(marker);
-        }
+        return findImplToUse().isTraceEnabled(marker);
     }
 
     @Override
     public void trace(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(msg);
-        } else {
-            findImplToUse().trace(msg);
-        }
+        findImplToUse().trace(msg);
     }
 
     @Override
     public void trace(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(format, arg);
-        } else {
-            findImplToUse().trace(format, arg);
-        }
+        findImplToUse().trace(format, arg);
     }
 
     @Override
     public void trace(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(format, arg1, arg2);
-        } else {
-            findImplToUse().trace(format, arg1, arg2);
-        }
+        findImplToUse().trace(format, arg1, arg2);
     }
 
     @Override
     public void trace(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(format, arguments);
-        } else {
-            findImplToUse().trace(format, arguments);
-        }
+        findImplToUse().trace(format, arguments);
     }
 
     @Override
     public void trace(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(msg, t);
-        } else {
-            findImplToUse().trace(msg, t);
-        }
+        findImplToUse().trace(msg, t);
     }
 
     @Override
     public void trace(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, msg);
-        } else {
-            findImplToUse().trace(marker, msg);
-        }
+        findImplToUse().trace(marker, msg);
     }
 
     @Override
     public void trace(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, format, arg);
-        } else {
-            findImplToUse().trace(marker, format, arg);
-        }
+        findImplToUse().trace(marker, format, arg);
     }
 
     @Override
     public void trace(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().trace(marker, format, arg1, arg2);
-        }
+        findImplToUse().trace(marker, format, arg1, arg2);
     }
 
     @Override
     public void trace(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, format, argArray);
-        } else {
-            findImplToUse().trace(marker, format, argArray);
-        }
+        findImplToUse().trace(marker, format, argArray);
     }
 
     @Override
     public void trace(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.trace(marker, msg, t);
-        } else {
-            findImplToUse().trace(marker, msg, t);
-        }
+        findImplToUse().trace(marker, msg, t);
     }
 
     @Override
     public boolean isDebugEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isDebugEnabled();
-        } else {
-            return findImplToUse().isDebugEnabled();
-        }
+        return findImplToUse().isDebugEnabled();
     }
 
     @Override
     public boolean isDebugEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isDebugEnabled(marker);
-        } else {
-            return findImplToUse().isDebugEnabled(marker);
-        }
+        return findImplToUse().isDebugEnabled(marker);
     }
 
     @Override
     public void debug(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(msg);
-        } else {
-            findImplToUse().debug(msg);
-        }
+        findImplToUse().debug(msg);
     }
 
     @Override
     public void debug(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(format, arg);
-        } else {
-            findImplToUse().debug(format, arg);
-        }
+        findImplToUse().debug(format, arg);
     }
 
     @Override
     public void debug(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(format, arg1, arg2);
-        } else {
-            findImplToUse().debug(format, arg1, arg2);
-        }
+        findImplToUse().debug(format, arg1, arg2);
     }
 
     @Override
     public void debug(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(format, arguments);
-        } else {
-            findImplToUse().debug(format, arguments);
-        }
+        findImplToUse().debug(format, arguments);
     }
 
     @Override
     public void debug(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(msg, t);
-        } else {
-            findImplToUse().debug(msg, t);
-        }
+        findImplToUse().debug(msg, t);
     }
 
     @Override
     public void debug(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, msg);
-        } else {
-            findImplToUse().debug(marker, msg);
-        }
+        findImplToUse().debug(marker, msg);
     }
 
     @Override
     public void debug(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, format, arg);
-        } else {
-            findImplToUse().debug(marker, format, arg);
-        }
+        findImplToUse().debug(marker, format, arg);
     }
 
     @Override
     public void debug(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().debug(marker, format, arg1, arg2);
-        }
+        findImplToUse().debug(marker, format, arg1, arg2);
     }
 
     @Override
     public void debug(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, format, argArray);
-        } else {
-            findImplToUse().debug(marker, format, argArray);
-        }
+        findImplToUse().debug(marker, format, argArray);
     }
 
     @Override
     public void debug(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.debug(marker, msg, t);
-        } else {
-            findImplToUse().debug(marker, msg, t);
-        }
+        findImplToUse().debug(marker, msg, t);
     }
 
     @Override
     public boolean isInfoEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isInfoEnabled();
-        } else {
-            return findImplToUse().isInfoEnabled();
-        }
+        return findImplToUse().isInfoEnabled();
     }
 
     @Override
     public boolean isInfoEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isInfoEnabled(marker);
-        } else {
-            return findImplToUse().isInfoEnabled(marker);
-        }
+        return findImplToUse().isInfoEnabled(marker);
     }
 
     @Override
     public void info(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(msg);
-        } else {
-            findImplToUse().info(msg);
-        }
+        findImplToUse().info(msg);
     }
 
     @Override
     public void info(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(format, arg);
-        } else {
-            findImplToUse().info(format, arg);
-        }
+        findImplToUse().info(format, arg);
     }
 
     @Override
     public void info(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.info(format, arg1, arg2);
-        } else {
-            findImplToUse().info(format, arg1, arg2);
-        }
+        findImplToUse().info(format, arg1, arg2);
     }
 
     @Override
     public void info(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.info(format, arguments);
-        } else {
-            findImplToUse().info(format, arguments);
-        }
+        findImplToUse().info(format, arguments);
     }
 
     @Override
     public void info(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.info(msg, t);
-        } else {
-            findImplToUse().info(msg, t);
-        }
+        findImplToUse().info(msg, t);
     }
 
     @Override
     public void info(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, msg);
-        } else {
-            findImplToUse().info(marker, msg);
-        }
+        findImplToUse().info(marker, msg);
     }
 
     @Override
     public void info(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, format, arg);
-        } else {
-            findImplToUse().info(marker, format, arg);
-        }
+        findImplToUse().info(marker, format, arg);
     }
 
     @Override
     public void info(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().info(marker, format, arg1, arg2);
-        }
+        findImplToUse().info(marker, format, arg1, arg2);
     }
 
     @Override
     public void info(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, format, argArray);
-        } else {
-            findImplToUse().info(marker, format, argArray);
-        }
+        findImplToUse().info(marker, format, argArray);
     }
 
     @Override
     public void info(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.info(marker, msg, t);
-        } else {
-            findImplToUse().info(marker, msg, t);
-        }
+        findImplToUse().info(marker, msg, t);
     }
 
     @Override
     public boolean isWarnEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isWarnEnabled();
-        } else {
-            return findImplToUse().isWarnEnabled();
-        }
+        return findImplToUse().isWarnEnabled();
     }
 
     @Override
     public boolean isWarnEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isWarnEnabled(marker);
-        } else {
-            return findImplToUse().isWarnEnabled(marker);
-        }
+        return findImplToUse().isWarnEnabled(marker);
     }
 
     @Override
     public void warn(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(msg);
-        } else {
-            findImplToUse().warn(msg);
-        }
+        findImplToUse().warn(msg);
     }
 
     @Override
     public void warn(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(format, arg);
-        } else {
-            findImplToUse().warn(format, arg);
-        }
+        findImplToUse().warn(format, arg);
     }
 
     @Override
     public void warn(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(format, arg1, arg2);
-        } else {
-            findImplToUse().warn(format, arg1, arg2);
-        }
+        findImplToUse().warn(format, arg1, arg2);
     }
 
     @Override
     public void warn(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(format, arguments);
-        } else {
-            findImplToUse().warn(format, arguments);
-        }
+        findImplToUse().warn(format, arguments);
     }
 
     @Override
     public void warn(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(msg, t);
-        } else {
-            findImplToUse().warn(msg, t);
-        }
+        findImplToUse().warn(msg, t);
     }
 
     @Override
     public void warn(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, msg);
-        } else {
-            findImplToUse().warn(marker, msg);
-        }
+        findImplToUse().warn(marker, msg);
     }
 
     @Override
     public void warn(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, format, arg);
-        } else {
-            findImplToUse().warn(marker, format, arg);
-        }
+        findImplToUse().warn(marker, format, arg);
     }
 
     @Override
     public void warn(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().warn(marker, format, arg1, arg2);
-        }
+        findImplToUse().warn(marker, format, arg1, arg2);
     }
 
     @Override
     public void warn(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, format, argArray);
-        } else {
-            findImplToUse().warn(marker, format, argArray);
-        }
+        findImplToUse().warn(marker, format, argArray);
     }
 
     @Override
     public void warn(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.warn(marker, msg, t);
-        } else {
-            findImplToUse().warn(marker, msg, t);
-        }
+        findImplToUse().warn(marker, msg, t);
     }
 
     @Override
     public boolean isErrorEnabled() {
-        if (this.properLogger != null) {
-            return this.properLogger.isErrorEnabled();
-        } else {
-            return findImplToUse().isErrorEnabled();
-        }
+        return findImplToUse().isErrorEnabled();
     }
 
     @Override
     public boolean isErrorEnabled(Marker marker) {
-        if (this.properLogger != null) {
-            return this.properLogger.isErrorEnabled(marker);
-        } else {
-            return findImplToUse().isErrorEnabled(marker);
-        }
+        return findImplToUse().isErrorEnabled(marker);
     }
 
     @Override
     public void error(String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(msg);
-        } else {
-            findImplToUse().error(msg);
-        }
+        findImplToUse().error(msg);
     }
 
     @Override
     public void error(String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(format, arg);
-        } else {
-            findImplToUse().error(format, arg);
-        }
+        findImplToUse().error(format, arg);
     }
 
     @Override
     public void error(String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.error(format, arg1, arg2);
-        } else {
-            findImplToUse().error(format, arg1, arg2);
-        }
+        findImplToUse().error(format, arg1, arg2);
     }
 
     @Override
     public void error(String format, Object... arguments) {
-        if (this.properLogger != null) {
-            this.properLogger.error(format, arguments);
-        } else {
-            findImplToUse().error(format, arguments);
-        }
+        findImplToUse().error(format, arguments);
     }
 
     @Override
     public void error(String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.error(msg, t);
-        } else {
-            findImplToUse().error(msg, t);
-        }
+        findImplToUse().error(msg, t);
     }
 
     @Override
     public void error(Marker marker, String msg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, msg);
-        } else {
-            findImplToUse().error(marker, msg);
-        }
+        findImplToUse().error(marker, msg);
     }
 
     @Override
     public void error(Marker marker, String format, Object arg) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, format, arg);
-        } else {
-            findImplToUse().error(marker, format, arg);
-        }
+        findImplToUse().error(marker, format, arg);
     }
 
     @Override
     public void error(Marker marker, String format, Object arg1, Object arg2) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, format, arg1, arg2);
-        } else {
-            findImplToUse().error(marker, format, arg1, arg2);
-        }
+        findImplToUse().error(marker, format, arg1, arg2);
     }
 
     @Override
     public void error(Marker marker, String format, Object... argArray) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, format, argArray);
-        } else {
-            findImplToUse().error(marker, format, argArray);
-        }
+        findImplToUse().error(marker, format, argArray);
     }
 
     @Override
     public void error(Marker marker, String msg, Throwable t) {
-        if (this.properLogger != null) {
-            this.properLogger.error(marker, msg, t);
-        } else {
-            findImplToUse().error(marker, msg, t);
-        }
+        findImplToUse().error(marker, msg, t);
     }
 
     private Logger findImplToUse() {
-        if (this.loggerFactory != null) {
-            Logger implToUse = this.loggerFactory.getLogger(this.className);
+        if (this.properLogger != null) {
+            return this.properLogger;
+        }
+
+        if (loggerFactory != null) {
+            Logger implToUse = loggerFactory.getLogger(this.className);
             synchronized (this) {
                 if (this.properLogger == null) {
                     this.properLogger = implToUse;

--- a/src/main/java/org/osc/controller/nuage/api/NuageSecurityControllerApi.java
+++ b/src/main/java/org/osc/controller/nuage/api/NuageSecurityControllerApi.java
@@ -9,13 +9,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import org.apache.log4j.Logger;
 import org.osc.sdk.controller.DefaultInspectionPort;
 import org.osc.sdk.controller.DefaultNetworkPort;
 import org.osc.sdk.controller.element.Element;
 import org.osc.sdk.controller.element.InspectionPortElement;
 import org.osc.sdk.controller.element.NetworkElement;
 import org.osc.sdk.controller.element.VirtualizationConnectorElement;
+import org.slf4j.Logger;
 import org.springframework.util.CollectionUtils;
 
 import net.nuagenetworks.bambou.RestException;
@@ -46,7 +46,7 @@ import net.nuagenetworks.vspk.v4_0.fetchers.RedirectionTargetsFetcher;
 import net.nuagenetworks.vspk.v4_0.fetchers.VPortsFetcher;
 
 public class NuageSecurityControllerApi implements Closeable {
-    private static final Logger LOG = Logger.getLogger(NuageSecurityControllerApi.class);
+    private static final Logger LOG = LogProvider.getLogger(NuageSecurityControllerApi.class);
 
     private NuageRestApi nuageRestApi = null;
 
@@ -579,7 +579,7 @@ public class NuageSecurityControllerApi implements Closeable {
                         break;
                     }
                     fwdPolicyJob.fetch();
-                    LOG.info(fwdPolicyJob);
+                    LOG.info(fwdPolicyJob.toString());
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }
@@ -601,7 +601,7 @@ public class NuageSecurityControllerApi implements Closeable {
                         break;
                     }
                     fwdPolicyJob.fetch();
-                    LOG.info(fwdPolicyJob);
+                    LOG.info(fwdPolicyJob.toString());
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/src/test/java/org/osc/controller/nuage/AbstractNuageTest.java
+++ b/src/test/java/org/osc/controller/nuage/AbstractNuageTest.java
@@ -9,18 +9,19 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 
-import org.apache.log4j.Logger;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.glassfish.jersey.jetty.JettyHttpContainerFactory;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.After;
 import org.junit.Before;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
 public class AbstractNuageTest {
-    Logger log = Logger.getLogger(AbstractNuageTest.class);
+    Logger log = LoggerFactory.getLogger(AbstractNuageTest.class);
 
     private Server server;
     protected int serverPort;

--- a/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
@@ -53,7 +53,8 @@ public class OSGiIntegrationTest extends AbstractNuageTest {
                 // And some dependencies
                 mavenBundle("org.apache.felix", "org.apache.felix.scr").versionAsInProject(),
 
-                mavenBundle("log4j", "log4j").versionAsInProject(),
+                mavenBundle("slf4j-api", "slf4j-api").versionAsInProject(),
+                mavenBundle("slf4j-simple", "slf4j-simple").versionAsInProject(),
                 mavenBundle("commons-logging", "commons-logging").versionAsInProject(),
                 mavenBundle("org.apache.directory.studio", "org.apache.commons.lang").versionAsInProject(),
                 mavenBundle("commons-codec", "commons-codec").versionAsInProject(),

--- a/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
@@ -54,6 +54,9 @@ public class OSGiIntegrationTest extends AbstractNuageTest {
                 mavenBundle("org.apache.felix", "org.apache.felix.scr").versionAsInProject(),
 
                 mavenBundle("org.slf4j", "slf4j-api").versionAsInProject(),
+                // Fragment bundles cannot be started
+                mavenBundle("org.slf4j", "slf4j-simple").versionAsInProject().noStart(),
+
                 mavenBundle("commons-logging", "commons-logging").versionAsInProject(),
                 mavenBundle("org.apache.directory.studio", "org.apache.commons.lang").versionAsInProject(),
                 mavenBundle("commons-codec", "commons-codec").versionAsInProject(),

--- a/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
+++ b/src/test/java/org/osc/controller/nuage/OSGiIntegrationTest.java
@@ -53,8 +53,7 @@ public class OSGiIntegrationTest extends AbstractNuageTest {
                 // And some dependencies
                 mavenBundle("org.apache.felix", "org.apache.felix.scr").versionAsInProject(),
 
-                mavenBundle("slf4j-api", "slf4j-api").versionAsInProject(),
-                mavenBundle("slf4j-simple", "slf4j-simple").versionAsInProject(),
+                mavenBundle("org.slf4j", "slf4j-api").versionAsInProject(),
                 mavenBundle("commons-logging", "commons-logging").versionAsInProject(),
                 mavenBundle("org.apache.directory.studio", "org.apache.commons.lang").versionAsInProject(),
                 mavenBundle("commons-codec", "commons-codec").versionAsInProject(),


### PR DESCRIPTION
* SFL4j is used in all non-core components. 
* logback is the logging framework used in osc-server. Easy to replace.
* osc-server publishes ILoggerFactory implementation for all other bundles.
* Witnessed logging functionality in osc-server, osc-ui and the NSC plugin.
* No mention of log4j anywhere in the project.